### PR TITLE
Include Lib/ScrollBox in release archive

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,10 @@ jobs:
       run: mkdir "$ARCHIVE_NAME"
     - name: Copy files
       run: cp -r *.ahk idledict.json *.ico README.md CHANGELOG.md CONTRIBUTING.md USER_MANUAL.md LICENSE "$ARCHIVE_NAME"
+    - name: Make Lib Folder
+      run: mkdir "$ARCHIVE_NAME/Lib"
+    - name: Copy Lib
+      run: cp Lib/ScrollBox.ahk "$ARCHIVE_NAME/Lib/"
     - name: Make Image Folder
       run: mkdir "$ARCHIVE_NAME/images"
     - name: Copy Images

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ To all the Idle Dragoneers who inspired and assisted me!
 
 ------
 
+## 3.79
+
+* Add USER_MANUAL.md — comprehensive user guide with feature reference, settings, hotkeys, and troubleshooting
+* Add CODE_DEPLOY.md — release pipeline documentation (CI → tag → draft → publish)
+* Add Documentation section to README.md linking all project markdown docs
+* Add USER_MANUAL.md to release archives (release.yml)
+* Fix release packaging: include Lib/ScrollBox.ahk in archives (app failed to launch without it)
+* Fix CI: pin AutoHotkey Chocolatey version to 1.1.37.1 (1.1.37.02 was delisted)
+* Fix CI: exclude vendored Lib/Yunit/ from markdownlint (14 false-positive errors)
+* Fix CI: change trigger from push+PR to PR-only
+* Fix CODE_DEPLOY.md markdownlint errors (MD004 dash→asterisk, MD029 ordered list prefix)
+
 ## 3.78
 
 * Fix Web Codes feature (site layout changed, old method broken)
@@ -94,10 +106,6 @@ To all the Idle Dragoneers who inspired and assisted me!
 * Cache UserDetails between sessions (loads cached data on startup, 1-hour TTL)
 * Non-blocking: Sleep calls in batch loops allow GUI message pump processing
 * SettingsCheckValue bumped to 24 (new: autorefreshminutes)
-* Add USER_MANUAL.md — comprehensive user guide with feature reference, settings, hotkeys, and troubleshooting
-* Add CODE_DEPLOY.md — release pipeline documentation (CI → tag → draft → publish)
-* Add Documentation section to README.md linking all project docs
-* Add USER_MANUAL.md to release archives (release.yml)
 
 ## 3.77
 

--- a/CODE_DEPLOY.md
+++ b/CODE_DEPLOY.md
@@ -94,6 +94,8 @@ idlecombos-vX.YZ/
 ├── CONTRIBUTING.md
 ├── USER_MANUAL.md
 ├── LICENSE
+├── Lib/
+│   └── ScrollBox.ahk       (vendored scrollable text display)
 ├── images/
 │   └── *.png              (13 GUI assets)
 └── styles/                (themes archive only)
@@ -110,10 +112,6 @@ idlecombos-vX.YZ/
 * `.vscode/` — editor config
 * `advdefs.json` — regenerated at runtime from API
 * All gitignored runtime files (settings, logs, caches)
-
-### Known Packaging Gap
-
-`Lib/ScrollBox.ahk` is `#Include`d by `IdleCombos.ahk` but is **not** copied into the release archive. If this file is required at runtime, `release.yml` needs a step to copy `Lib/` contents. Currently the app will fail to launch from a release archive if ScrollBox is expected.
 
 ## CI Pipeline Detail
 

--- a/IdleCombos.ahk
+++ b/IdleCombos.ahk
@@ -7,7 +7,7 @@
 #include Lib\ScrollBox.ahk
 
 ;Versions
-global VersionNumber := "3.78"
+global VersionNumber := "3.79"
 global CurrentDictionary := "2.41"
 
 ;Local File globals

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Companion App for Idle Champions, written in [AHK](https://www.autohotkey.com/).
 
-**v3.78** is the current supported Version. [View changelog.](https://github.com/djravine/idlecombos/blob/master/CHANGELOG.md)
+**v3.79** is the current supported Version. [View changelog.](https://github.com/djravine/idlecombos/blob/master/CHANGELOG.md)
 
 ![Screenshot](https://i.imgur.com/LoeTt9r.png)
 


### PR DESCRIPTION
Add workflow steps to .github/workflows/release.yml to create a Lib folder and copy Lib/ScrollBox.ahk into the release archive so the vendored scrollable text display is bundled. Update CODE_DEPLOY.md to list Lib/ScrollBox and remove the prior "Known Packaging Gap" note about ScrollBox not being copied.